### PR TITLE
Correcting code

### DIFF
--- a/coaching-app/app.json
+++ b/coaching-app/app.json
@@ -3,6 +3,7 @@
     "name": "coaching-tmp",
     "slug": "coaching-tmp",
     "version": "1.0.0",
+    "entryPoint": "./index.js",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",


### PR DESCRIPTION
Add `entryPoint` to `app.json` to explicitly set Expo to start from `./index.js`.

The previous configuration was causing Expo to use `node_modules/expo/AppEntry.js`, which failed to resolve the main `App` component, leading to a build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca2e743d-9eee-4f53-a8ca-d260c967eed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca2e743d-9eee-4f53-a8ca-d260c967eed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

